### PR TITLE
Update broken URLs & Some other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub branch checks state](https://img.shields.io/github/checks-status/fossbilling/fossbilling.org/main)](https://github.com/fossbilling/fossbilling.org/actions/workflows)
 
-FOSSBilling's website and documentation. Built using [Docusaurus 2](https://docusaurus.io/), hosted on Cloudflare Pages and can be reached by visiting [https://fossbilling.org](fossbilling.org).
+FOSSBilling's website and documentation. Built using [Docusaurus 2](https://docusaurus.io/), hosted on Cloudflare Pages and can be reached by visiting [fossbilling.org](https://fossbilling.org).
 
 ### Installation
 

--- a/docs/contribution-handbook/code-of-conduct.mdx
+++ b/docs/contribution-handbook/code-of-conduct.mdx
@@ -63,7 +63,7 @@ representative at an online or offline event. Representation of a project may be
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at our [Discord](https://fossbilling.org/discord) and [Slack](https://fossbilling.org/slack) communities. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at our [Discord](https://fossbilling.org/discord) community. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -31,7 +31,7 @@ We would love it if FOSSBilling could do everything that everyone will ever ask 
 
 Even though the specific thing that you particularly need might not be available in core, FOSSBilling is designed to be easily extendable. If you have the knowledge to build an extension yourself then we would love the contribution, if not then we recommend reaching out to the community and seeing if someone else will be willing to build or update it for you.
 
-You can search for existing feature requests and add new ones on our [GitHub Issues page](https://github.com/FOSSBilling/FOSSBilling/issues).
+You can [search for existing feature requests](https://github.com/FOSSBilling/FOSSBilling/issues?q=is:open+is:issue+label:"feature+request") and [add new ones](/feature-request).
 
 ## Do I need to pay for FOSSBilling?
 

--- a/docs/getting-started/cPanel.mdx
+++ b/docs/getting-started/cPanel.mdx
@@ -9,7 +9,7 @@ cPanel is one of the most popular hosting platforms in the world. In this guide,
 
 :::info
 
-This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the master branch instead.
+This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the main branch instead.
 
 :::
 

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -9,7 +9,7 @@ Docker is the recommended way to install FOSSBilling. It's easy to use, and it's
 
 :::caution
 
-This guide will build FOSSBilling from the master branch. It should be okay if you're planning to use it for testing or development. Be careful when using in production.
+This guide will build FOSSBilling from the main branch. It should be okay if you're planning to use it for testing or development. Be careful when using in production.
 
 :::
 

--- a/docs/getting-started/nginx.mdx
+++ b/docs/getting-started/nginx.mdx
@@ -9,7 +9,7 @@ nginx is a pretty popular pretty popular web server that can also be used as a r
 
 :::info
 
-This guide will install the latest **preview release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the master branch instead.
+This guide will install the latest **preview release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the main branch instead.
 
 :::
 

--- a/docs/getting-started/plesk.mdx
+++ b/docs/getting-started/plesk.mdx
@@ -9,7 +9,7 @@ Plesk is one of the most popular hosting platforms in the world. In this guide, 
 
 :::info
 
-This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the master branch instead.
+This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the main branch instead.
 
 :::
 


### PR DESCRIPTION
The following changes were made:
* Update the README URL to correctly direct to the FOSSBilling website. It was missing the "https://" part and was trying to direct to a GitHub directory.
* Update the Code of Conduct to remove the Slack leftover.

The following changes were made in a separate commit for an easier revert if they're not desired:
* Rename master to main. While "master branch" remains a valid term, it is my belief this will help avoid any potential confusion.
* Update the feature request URLs. Currently, the FAQ link directs to the Issues page, I removed that and instead added two new links, the first one linking "search for existing feature requests" to [the Issues page, filtered with feature requests only](https://github.com/FOSSBilling/FOSSBilling/issues?q=is:open+is:issue+label:%22feature+request%22) and the second one, "add new ones", utilizes [the site's feature request opener URL](https://fossbilling.org/feature-request)].

Feel free to make any changes / ask me to change anything.