### PR TITLE
Create a new release download URL & some other updates

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -2,10 +2,12 @@
 /discord /discord/ 301
 /donate /donate/ 301
 /feature-request /feature-request/ 301
+/downloads/stable /downloads/stable/ 301
 /downloads/preview /downloads/preview/ 301
 
 /bug-report/ https://github.com/FOSSBilling/FOSSBilling/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBug%5D 301
 /discord/ https://discord.com/invite/bVjMZSgtbY 301
 /donate/ https://github.com/sponsors/FOSSBilling 301
 /feature-request/ https://github.com/FOSSBilling/FOSSBilling/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=%5BFeature+Request%5D 301
+/downloads/stable/ https://github.com/FOSSBilling/FOSSBilling/releases/latest/download/FOSSBilling.zip 301
 /downloads/preview/ https://s4-fossb-2.fi-hel2.upcloudobjects.com/releases/FOSSBilling-preview.zip 301

--- a/docs/getting-started/cPanel.mdx
+++ b/docs/getting-started/cPanel.mdx
@@ -9,14 +9,14 @@ cPanel is one of the most popular hosting platforms in the world. In this guide,
 
 :::info
 
-This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to build FOSSBilling from the main branch instead.
+This guide will install the latest **release**. If you're planning to contribute to the development of FOSSBilling, it's strongly advised to [download a preview build](https://fossbilling.org/downloads/preview) or build FOSSBilling from the main branch instead.
 
 :::
 
 ## Instructions
 
-### Download the latest preview build
-Download the latest preview build of FOSSBilling from GitHub using this link: [Latest Preview Build](https://fossbilling.org/downloads/preview)
+### Download the latest release
+Download the latest release of FOSSBilling using this link: [Latest Stable Release](https://fossbilling.org/downloads/stable)
 
 ### Upload the files to your web server
 #### Using the bundled file manager

--- a/docs/getting-started/migrate-from-boxbilling.mdx
+++ b/docs/getting-started/migrate-from-boxbilling.mdx
@@ -34,9 +34,9 @@ Before you do anything, make sure that you do a full backup (or two) of both the
 
 :::
 
-### Download the latest preview build
+### Download the latest release
 
-Download the latest preview build of FOSSBilling from GitHub using this link: [Latest Preview Build](https://fossbilling.org/downloads/preview)
+Download the latest release of FOSSBilling using this link: [Latest Stable Release](https://fossbilling.org/downloads/stable)
 
 ### Prepare your existing installation
 
@@ -61,7 +61,7 @@ Upload and extract the contents of the preview build archive over the files in y
 You can either do this using either of the following methods:
 
 * **Recommended:** log into the admin panel, go to the "Update FOSSBilling" and use the "Migrate configuration" tool.
-  * Note: if you are using custom values for `locale_date_format` or `locale_time_format`, you will need to manually update these to the [datetime format](https://www.php.net/manual/en/datetime.format.php)
+  * Note: if you are using custom values for `locale_date_format` or `locale_time_format`, you will need to manually update these to the [datetime format](https://www.php.net/manual/en/datetime.format.php).
 * **Not Recommended** Rename 'config-sample.php' to 'config.php' and then copy the values from your old configuration file (database name, etc.) into the new configuration file. 
 
 ### Run foss-update

--- a/docs/getting-started/nginx.mdx
+++ b/docs/getting-started/nginx.mdx
@@ -15,8 +15,8 @@ This guide will install the latest **preview release**. If you're planning to co
 
 ## Prerequisites
 You will need to have the following installed. Please take a moment now to make sure you are ready:
-* **nginx** [Install guide](https://www.digitalocean.com/community/tutorial_collections/how-to-install-nginx). Please skip the "Setting Up Server Blocks" part, we'll cover that in this guide)
-* **PHP 8.0** or later [Guide to install 8.1 on Ubuntu 22.04](https://www.digitalocean.com/community/tutorials/how-to-install-php-8-1-and-set-up-a-local-development-environment-on-ubuntu-22-04))
+* **nginx** ([Install guide](https://www.digitalocean.com/community/tutorial_collections/how-to-install-nginx)). Please skip the "Setting Up Server Blocks" part, we'll cover that in this guide)
+* **PHP 8.0** or later ([Guide to install 8.1 on Ubuntu 22.04](https://www.digitalocean.com/community/tutorials/how-to-install-php-8-1-and-set-up-a-local-development-environment-on-ubuntu-22-04))
 * The following PHP extensions (the guide above also has a section that covers installing PHP extensions): `pdo_mysql`, `curl`, `zlib`, `gettext`, `openssl`
 * **MariaDB 10.3** or later, or **MySQL 8** or later ([guide to install MariaDB](https://www.digitalocean.com/community/tutorial_collections/how-to-install-mariadb)) 
 
@@ -39,7 +39,7 @@ If you need help writing your nginx config file, or just want to check what you 
 * Run `sudo systemctl restart nginx`
 
 ### Installing FOSSBilling
-* Download the latest [FOSSBilling preview](https://fossbilling.org/downloads/preview) and then upload the files in the archive to the public directory of the site on your server, keeping the file structure as it is inside the archive.  
+* Download the latest [FOSSBilling release](https://fossbilling.org/downloads/stable) and then upload the files in the archive to the public directory of the site on your server, keeping the file structure as it is inside the archive.  
 * Navigate to  to the install page on your domain (i.e fossbilling.example.com/install) 
 * Ensure the following have public write access, `/var/www/.../src/config.php`, `/var/www/.../src/data/cache`, `/var/www/.../src/data/log`, `/var/www/.../src/data/uploads`
 * Setup the database under the database tab

--- a/docs/getting-started/plesk.mdx
+++ b/docs/getting-started/plesk.mdx
@@ -15,8 +15,8 @@ This guide will install the latest **release**. If you're planning to contribute
 
 ## Instructions
 
-### Download the latest preview build
-Download the latest preview build of FOSSBilling from GitHub using this link: [Latest Preview Build](https://fossbilling.org/downloads/preview)
+### Download the latest release
+Download the latest release of FOSSBilling using this link: [Latest Stable Release](https://fossbilling.org/downloads/stable)
 
 ### Upload the files to your web server
 #### Using the bundled file manager

--- a/docs/maintaining-fossbilling/updating.mdx
+++ b/docs/maintaining-fossbilling/updating.mdx
@@ -16,7 +16,7 @@ Before performing either option, it is recommended to create a backup of both yo
 
 ## Manually Updating FOSSBilling
 
- 1. Download the latest version of FOSSBilling
+ 1. [Download the latest version of FOSSBilling](https://fossbilling.org/downloads/stable)
  2. Extract the latest release on-top of your existing installation, overriding existing files
  3. Run yourdomain.com/foss-update.php
  4. Log in to the admin panel and go to `extensions` --> `overview` --> `Update FOSSBilling`.  Then run the `Migrate configuration` option to ensure your configuration is up-to-date.

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -15,8 +15,8 @@ function Header() {
         <div className={styles.buttons}>
           <a
             className="button button--secondary button--lg"
-            href="https://github.com/FOSSBilling/FOSSBilling/releases/download/0.1.0/FOSSBilling.zip">
-            Download v0.1.0
+            href="https://fossbilling.org/downloads/stable">
+            Download v0.1.1
           </a>
         </div>
       </div>


### PR DESCRIPTION
* Create fossbilling.org/downloads/stable, which automatically fetches the latest release from GitHub so that the link does not need to be manually updated.
* Update version to 0.1.1.
* Add some missing parentheses and dots.

Feel free to (ask me to) change anything. You can test that the new URL works fine by visiting my test site, https://anyx-fossbilling.pages.dev/downloads/stable.

[The behavior of the GitHub API when fetching /latest is set to skip pre-releases and drafts](https://docs.github.com/en/rest/releases/releases#get-the-latest-release), so there's no worry about a potentially non-stable release being served by it.