### PR TITLE
Fix npm install command

### DIFF
--- a/pages/docs/getting-started/building.mdx
+++ b/pages/docs/getting-started/building.mdx
@@ -17,7 +17,7 @@ import { Callout } from 'nextra-theme-docs'
 Building FOSSBilling from the source code is rather simple and only requires a few simple steps.
 
 1. Clone the FOSSBilling repository and then move to that directory: `git clone https://github.com/FOSSBilling/FOSSBilling.git && cd FOSSBilling`
-2. Install NPM dependencies: `npm -i`
+2. Install NPM dependencies: `npm i`
 3. Install composer dependencies: `composer install`
 4. Build the front-end assets: `npm run build`
 5. (_Optional_) Download the [latest translations](https://github.com/FOSSBilling/locale/releases/tag/latest) from the locale repository and extract the contents to the `src/locale` directory. Ensure you overwrite any existing files.


### PR DESCRIPTION
This commit fixes the building page of the documentation. Npm modules are installed with `npm i`, not with `npm -i`.