### PR TITLE
Bump banner version to 0.8.4 and improve upgrade recommendation

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -19,7 +19,7 @@ export default function Banner() {
 
   return (
     <div className="z-40 bg-black text-white text-center text-sm py-2 px-4">
-      FOSSBilling {RELEASE_VERSION} is now available!{' '}
+      <span className="font-semibold">FOSSBilling {RELEASE_VERSION} is now available!</span> We strongly recommend upgrading from older versions.{' '}
       <a
         href="https://github.com/FOSSBilling/FOSSBilling/releases/latest"
         target="_blank"

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 
-const RELEASE_VERSION = '0.8.3'
+const RELEASE_VERSION = '0.8.4'
 
 export default function Banner() {
   const [hidden, setHidden] = useState(false)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the top banner to announce FOSSBilling 0.8.4. The message is now bold and explicitly recommends upgrading from older versions.

<sup>Written for commit b2345585b05109193a3db396ec8e11bf2b044618. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

