### PR TITLE
Fix CSP by using Astro's security.csp for nonce-based scripts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,22 @@ export default defineConfig({
   output: 'server',
   adapter: cloudflare(),
   integrations: [sitemap()],
+  security: {
+    csp: {
+      directives: [
+        "default-src 'self'",
+        "base-uri 'self'",
+        "object-src 'none'",
+        "frame-ancestors 'none'",
+        "img-src 'self' data: blob: https://raw.githubusercontent.com",
+        "font-src 'self' data:",
+        "connect-src 'self' https://api.github.com https://api.fossbilling.net",
+      ],
+      scriptDirective: {
+        resources: ['https://static.cloudflareinsights.com'],
+      },
+    },
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,7 @@
 # Security headers applied to all routes
+# CSP is handled by Astro's security.csp config (meta tag with script/style hashes)
 
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://raw.githubusercontent.com; font-src 'self' data:; connect-src 'self' https://api.github.com https://api.fossbilling.net
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
Enable Astro's security.csp which automatically generates per-request nonces for all inline scripts (including is:inline theme init script) via the Cloudflare adapter. Move CSP directives (default-src, img-src, connect-src, etc.) to the Astro config. Keep other security headers (Referrer-Policy, X-Frame-Options, etc.) in _headers.