### PR TITLE
Align CSP handling with Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,22 +10,6 @@ export default defineConfig({
   output: 'server',
   adapter: cloudflare({ prerenderEnvironment: 'node' }),
   integrations: [sitemap()],
-  security: {
-    csp: {
-      directives: [
-        "default-src 'self'",
-        "base-uri 'self'",
-        "object-src 'none'",
-        "frame-ancestors 'none'",
-        "img-src 'self' data: blob: https://raw.githubusercontent.com",
-        "font-src 'self' data:",
-        "connect-src 'self' https://api.github.com https://api.fossbilling.net",
-      ],
-      scriptDirective: {
-        resources: ["'self'", 'https://static.cloudflareinsights.com'],
-      },
-    },
-  },
   vite: {
     plugins: [tailwindcss()],
     ssr: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
         "connect-src 'self' https://api.github.com https://api.fossbilling.net",
       ],
       scriptDirective: {
-        resources: ['https://static.cloudflareinsights.com'],
+        resources: ["'self'", 'https://static.cloudflareinsights.com'],
       },
     },
   },

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,6 @@
 # Security headers applied to all routes
-# CSP is handled by Astro's security.csp config (meta tag with script/style hashes)
+# CSP and these headers are also set by Astro middleware (src/middleware.ts) for SSR routes
+# CSP itself is handled by Astro's security.csp config (astro.config.mjs)
 
 /*
   Referrer-Policy: strict-origin-when-cross-origin

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,5 @@
 # Security headers applied to all routes
 # CSP and these headers are also set by Astro middleware (src/middleware.ts) for SSR routes
-# CSP itself is handled by Astro's security.csp config (astro.config.mjs)
 
 /*
   Referrer-Policy: strict-origin-when-cross-origin

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="astro/client" />
+
+declare namespace App {
+  interface Locals {
+    nonce: string;
+  }
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,9 +26,6 @@ const githubToken = (env as unknown as Record<string, string | undefined>)[
 ];
 const stars = await getGitHubStarCount(githubToken);
 
-const nonce = (Astro.locals as unknown as Record<string, unknown>)
-  .nonce as string;
-
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
 ---
@@ -56,7 +53,7 @@ const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
     <meta name="twitter:domain" content="fossbilling.org" />
     <meta name="twitter:url" content={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
-    <script is:inline nonce={nonce}>
+    <script is:inline>
       (function () {
         try {
           var t = localStorage.getItem('theme');
@@ -189,6 +186,6 @@ const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
       </div>
     </footer>
 
-    <script src="/js/app.js" defer nonce={nonce}></script>
+    <script is:inline src="/js/app.js" defer></script>
   </body>
 </html>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,6 +26,9 @@ const githubToken = (env as unknown as Record<string, string | undefined>)[
 ];
 const stars = await getGitHubStarCount(githubToken);
 
+const nonce = (Astro.locals as unknown as Record<string, unknown>)
+  .nonce as string;
+
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
 ---
@@ -53,7 +56,7 @@ const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
     <meta name="twitter:domain" content="fossbilling.org" />
     <meta name="twitter:url" content={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
-    <script is:inline>
+    <script is:inline nonce={nonce}>
       (function () {
         try {
           var t = localStorage.getItem('theme');
@@ -186,6 +189,6 @@ const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);
       </div>
     </footer>
 
-    <script is:inline src="/js/app.js" defer></script>
+    <script is:inline src="/js/app.js" defer nonce={nonce}></script>
   </body>
 </html>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,8 +26,7 @@ const githubToken = (env as unknown as Record<string, string | undefined>)[
 ];
 const stars = await getGitHubStarCount(githubToken);
 
-const nonce = (Astro.locals as unknown as Record<string, unknown>)
-  .nonce as string;
+const nonce = Astro.locals.nonce;
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 const ogImage = ogImageUrlFor(Astro.url.pathname, Astro.url.origin);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,16 +8,9 @@ const SECURITY_HEADERS: Record<string, string> = {
     'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
 };
 
-export const onRequest = defineMiddleware(async (context, next) => {
-  const nonce = crypto.randomUUID();
-  (context.locals as unknown as Record<string, unknown>).nonce = nonce;
-
+export const onRequest = defineMiddleware(async (_context, next) => {
   const response = await next();
 
-  response.headers.set(
-    'Content-Security-Policy',
-    `default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://raw.githubusercontent.com; font-src 'self' data:; connect-src 'self' https://api.github.com https://api.fossbilling.net`,
-  );
   for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
     response.headers.set(key, value);
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ const SECURITY_HEADERS: Record<string, string> = {
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const nonce = crypto.randomUUID();
-  (context.locals as unknown as Record<string, unknown>).nonce = nonce;
+  context.locals.nonce = nonce;
 
   const response = await next();
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,9 +8,16 @@ const SECURITY_HEADERS: Record<string, string> = {
     'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
 };
 
-export const onRequest = defineMiddleware(async (_context, next) => {
+export const onRequest = defineMiddleware(async (context, next) => {
+  const nonce = crypto.randomUUID();
+  (context.locals as unknown as Record<string, unknown>).nonce = nonce;
+
   const response = await next();
 
+  response.headers.set(
+    'Content-Security-Policy',
+    `default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'nonce-${nonce}' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://raw.githubusercontent.com; font-src 'self' data:; connect-src 'self' https://api.github.com https://api.fossbilling.net`,
+  );
   for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
     response.headers.set(key, value);
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves CSP to nonce-based middleware and removes Astro’s `security.csp` for per-request control on SSR pages. Types `Astro.locals.nonce` and aligns the base script and headers with the new flow.

- **Refactors**
  - Removed `security.csp` from `astro.config.mjs`; CSP is now set in `src/middleware.ts` with `'self'`, per-request nonce, and `https://static.cloudflareinsights.com` (other security headers unchanged).
  - Added `src/env.d.ts` to type `App.Locals.nonce`; set `context.locals.nonce` in middleware and use `Astro.locals.nonce` in templates; switched app script to `is:inline` with `nonce`.
  - Updated `public/_headers` comments to note middleware-managed CSP for SSR routes.

<sup>Written for commit f4d214426d7c7185b05062a9e595476704b14744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

