### PR TITLE
Optimize CI workflows and cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     name: Typecheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id) || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v7
@@ -19,12 +23,12 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --no-audit --no-fund
       - run: npm run check
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id) || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v7
@@ -32,12 +36,12 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --no-audit --no-fund
       - run: npm run build
 
   format:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id) || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v7
@@ -45,5 +49,5 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --no-audit --no-fund
       - run: npm run format:check

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,9 +15,13 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v7


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up CI and reduce noise by canceling stale runs via workflow concurrency, switching runners to `ubuntu-slim`, and using `npm ci --no-audit --no-fund` across `typecheck`, `build`, `format`, and dependency-review jobs.

<sup>Written for commit 1ecf338b207e42dfdc35178d334cc543125dfad1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

