### PR TITLE
Add trailing-slash download redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -5,7 +5,9 @@
 /donate         https://github.com/sponsors/FOSSBilling 301
 /feature-request https://github.com/FOSSBilling/FOSSBilling/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=%5BFeature+Request%5D 301
 /downloads/stable https://github.com/FOSSBilling/FOSSBilling/releases/latest/download/FOSSBilling.zip 301
+/downloads/stable/ https://github.com/FOSSBilling/FOSSBilling/releases/latest/download/FOSSBilling.zip 301
 /downloads/preview https://download.fossbilling.org/FOSSBilling-preview.zip 301
+/downloads/preview/ https://download.fossbilling.org/FOSSBilling-preview.zip 301
 
 /api/central-alerts/* https://api.fossbilling.net/central-alerts/v1/:splat 308
 


### PR DESCRIPTION
Adds `/downloads/stable/` and `/downloads/preview/` redirects alongside the existing non-trailing-slash routes so both URL forms resolve correctly to the same download targets.