### PR TITLE
Update Renovate configuration for daily schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
     ":automergeTypes",
-    ":combinePatchMinorReleases",
     ":maintainLockFilesWeekly",
     ":npm",
     ":rebaseStalePrs"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,19 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly",
+    "schedule:daily",
+    "security:minimumReleaseAgeNpm",
     ":automergeBranch",
     ":automergeDigest",
     ":automergeLinters",
-    ":automergeMinor",
+    ":automergePatch",
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
     ":automergeTypes",
     ":combinePatchMinorReleases",
     ":maintainLockFilesWeekly",
-    ":prHourlyLimit2",
+    ":npm",
     ":rebaseStalePrs"
   ],
   "automergeSchedule": ["at any time"],
-  "automergeStrategy": "squash"
+  "automergeStrategy": "squash",
+  "postUpdateOptions": ["npmDedupe"],
+  "skipInstalls": false
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changes Renovate to check for dependency updates daily instead of weekly, and tightens how updates are automerged.

- Automerge now applies only to patch releases, not minor ones, and patch and minor releases are no longer combined into one PR.
- npm packages must meet a minimum release age before being updated.
- Enables npm dedupe and keeps installs enabled.
- Removes the hourly PR limit.

<sup>Written for commit 099debdac278583b43c057c6d95723e3b64e31cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

